### PR TITLE
adjust the logging to use bunyan, and fix eslint no-console

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,6 @@
     "strict": [2, "global"],
     "semi": [2, "always"],
     "no-var": 2,
-    "one-var": [2, "never"],
-    "no-console": "off",
+    "one-var": [2, "never"]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1333,12 +1333,12 @@
       "dev": true
     },
     "bunyan": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
-      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "version": "1.8.15",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.15.tgz",
+      "integrity": "sha512-0tECWShh6wUysgucJcBAoYegf3JJoZWibxdqhTm7OHPeT42qdjkZ29QCMcKwbgU1kiH+auSIasNRXMLWXafXig==",
       "requires": {
         "dtrace-provider": "~0.8",
-        "moment": "^2.10.6",
+        "moment": "^2.19.3",
         "mv": "~2",
         "safe-json-stringify": "~1"
       }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "awaitability": "0.0.1",
     "backbone": "^1.3.3",
     "body-parser": "^1.9.0",
+    "bunyan": "^1.8.15",
     "codemirror": "^5.31.0",
     "cookie-parser": "^1.3.3",
     "express": "^4.16.2",

--- a/server/log.js
+++ b/server/log.js
@@ -1,14 +1,18 @@
 'use strict';
 
-/* eslint-disable no-console */
+const config = require('../config');
+let bunyan = require('bunyan');
+let log = bunyan.createLogger({name: config.branding.title}); 
+ 
+const logger = function(){
+    let a = arguments;
+    log.debug.apply(log, a);
+};
 
-const logger = console.log.bind(console);
-
-logger.debug = console.debug;
-logger.info = console.info;
-logger.warn = console.warn;
-logger.error = console.error;
-
-/* eslint-enable no-console */
+logger.debug = log.debug.bind(log);
+logger.info = log.info.bind(log);
+logger.warn = log.warn.bind(log);
+logger.error = log.error.bind(log);
+ 
 
 module.exports = logger;

--- a/server/mailer.js
+++ b/server/mailer.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const _ = require('lodash');
+const _ = require('lodash'); 
+
 const env = function(x) {
   return process.env["MAILER_" + (x.toUpperCase())];
 };
@@ -100,7 +101,7 @@ const createTransport = function(arg) {
             response: response
           }, "message sent");
         } else {
-          console.error("no error and no info?");
+          log("no error and no info?");
         }
         return cb && cb(err, info);
       };


### PR DESCRIPTION
I added the code for the bunyan, and adjust the log.js file to reuse bunyan isntead of the console.log and remove the eslint no-console.


```
const config = require('../config');
let bunyan = require('bunyan');
let log = bunyan.createLogger({name: config.branding.title}); 
 
const logger = function(){
    let a = arguments;
    log.debug.apply(log, a);
};

logger.debug = log.debug.bind(log);
logger.info = log.info.bind(log);
logger.warn = log.warn.bind(log);
logger.error = log.error.bind(log);
 

module.exports = logger;
```
